### PR TITLE
Revert "Fix for IDN domains"

### DIFF
--- a/dns_yandex360.sh
+++ b/dns_yandex360.sh
@@ -15,7 +15,7 @@
 
 #Usage: dns_myapi_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_yandex360_add() {
-  fulldomain=`idn "${1}"`
+  fulldomain="${1}"
   txtvalue="${2}"
   _debug "Calling: dns_yandex360_add() '${fulldomain}' '${txtvalue}'"
 
@@ -44,7 +44,7 @@ dns_yandex360_add() {
 
 #Usage: dns_myapi_rm   _acme-challenge.www.domain.com
 dns_yandex360_rm() {
-  fulldomain=`idn "${1}"`
+  fulldomain="${1}"
   _debug "Calling: dns_yandex360_rm() '${fulldomain}'"
 
   _y360_credentials || return 1


### PR DESCRIPTION
Reverts subregular/acme.sh-dns_yandex360#1

Need to redo the root domain identification, with the option of internationalized domain names.

if the domain is indeed an IDN.
if there is an "idn" application in the system.
Possible to do with acme.sh built-in function "_idn() "
